### PR TITLE
added demonet private key for user testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The endpoint can then be tested using curl
 ```
 curl -X POST http://localhost:3000 \
 -H "Content-Type: application/json" \
--d '{"pk": "'"$WEB3_PRIVATE_KEY"'", "module": "github.com/lilypad-tech/lilypad-module-lilysay:0.1.0", "inputs": "-i Message=test"}'
+-d '{"pk": "'"b3994e7660abe5f65f729bb64163c6cd6b7d0b1a8c67881a7346e3e8c7f026f5"'", "module": "github.com/lilypad-tech/lilypad-module-lilysay:0.1.0", "inputs": "-i Message=test"}'
 ```
 
 ```js


### PR DESCRIPTION
added a private key that has been provisioned for using the JS CLI wrapper on demonet. This has been setup for users to easily run jobs on lilypad, this privatekey is a dev key and does not have any funds outside of the testnet tokens used to run jobs.